### PR TITLE
Fix queries

### DIFF
--- a/app/controllers/fights_controller.rb
+++ b/app/controllers/fights_controller.rb
@@ -34,13 +34,7 @@ class FightsController < ApplicationController
     end
 
     def new_fight = Fight.new(permitted_params)
-
-    # TODO: yeah, it looks weird but #find will add extra sql request
-    def existing_fight  
-      Fight.eager_load(:rounds, :ring).where(id: params[:id]).to_a.first.tap do
-        raise ActiveRecord::RecordNotFound if _1.nil?
-      end
-    end
+    def existing_fight = Fight.eager_load(:ring).find(params[:id])
 
     def enemy
       @enemy ||= fight.current_enemy

--- a/app/controllers/replays_controller.rb
+++ b/app/controllers/replays_controller.rb
@@ -11,16 +11,12 @@ class ReplaysController < ApplicationController
 
     def check_fight = fight.score.present? || redirect_to(fight_path(fight))
 
-    # TODO: yeah, it looks weird but #find will add extra sql request
     def fight
-      @fight ||= Fight
-        .eager_load(:band, rounds: %i(enemy puppets))
-        .where(id: params[:id])
-        .to_a.first.tap { raise ActiveRecord::RecordNotFound if _1.nil? }
+      @fight ||= Fight.eager_load(:band).find(params[:id])
     end
 
     def frames
-      @frames ||= fight.rounds.uniq(&:enemy_id).map do
+      @frames ||= fight.rounds.includes(:puppets).map do
         _1.as_json(only: %i(fight_id enemy_id)).merge('class' => _1.win? ? :success : :failure)
       end
     end


### PR DESCRIPTION
Looks like eager_load for 1:M associations
can return unexpected results.

For example:

```Ruby
Fight
  .eager_load(rounds: :enemy)
  .find(5)
  .rounds
  .first
  .then { [_1.enemy_id, _1.enemy.id] } #=> [1,5]
```

```Ruby
Fight
  .find(2)
  .rounds
  .eager_load(:puppets)
  .find_by(enemy_id: 25)
  .puppet_names #=> ['A', 'A']
```